### PR TITLE
Changed from the default app id, to a more appropriate home class

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <div class="Home">
     <AddTodo v-on:add-todo="addTodo" />
     <Todos v-bind:todos="todos" v-on:del-todo="deleteTodo" />
   </div>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="Home">
+  <div class="home">
     <AddTodo v-on:add-todo="addTodo" />
     <Todos v-bind:todos="todos" v-on:del-todo="deleteTodo" />
   </div>


### PR DESCRIPTION
The default page had id `app` but after adding router this is set on the app wrapper, so Home page should have a class of `home`.